### PR TITLE
Fix input and add acceleration to motion system

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ impl event::EventHandler for MainState {
     ) {
         if let Some(ev) = self.input_binding.resolve(keycode) {
             self.scenes.input(ev, true);
+            self.scenes.world.input.update_effect(ev, true);
         }
     }
 
@@ -71,6 +72,7 @@ impl event::EventHandler for MainState {
     ) {
         if let Some(ev) = self.input_binding.resolve(keycode) {
             self.scenes.input(ev, false);
+            self.scenes.world.input.update_effect(ev, false);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ impl MainState {
     fn new(ctx: &mut Context, resource_path: &path::Path) -> Self {
         let world = world::World::new(resource_path);
         let mut scenestack = scenes::Stack::new(ctx, world);
-        let initial_scene = Box::new(scenes::level::LevelScene::new(ctx, &mut scenestack.world));
+        let initial_scene = Box::new(scenes::menu::MenuScene::new(ctx, &mut scenestack.world));
         scenestack.push(initial_scene);
 
         Self {

--- a/src/scenes/menu.rs
+++ b/src/scenes/menu.rs
@@ -1,0 +1,64 @@
+use ggez;
+use ggez::graphics;
+use ggez_goodies::scene;
+use log::*;
+
+use crate::input;
+use crate::world::World;
+use crate::scenes;
+use crate::types::*;
+
+pub struct MenuScene {
+    title_text: graphics::Text,
+    input_text: graphics::Text,
+    done: bool,
+}
+
+impl MenuScene {
+    pub fn new(ctx: &mut ggez::Context, _world: &mut World) -> Self {
+        let font = graphics::Font::new(ctx, "/fonts/DejaVuSerif.ttf").unwrap();
+        let title_text = graphics::Text::new(("Main Menu", font, 48.0));
+        let input_text = graphics::Text::new(("Press Any Key to Start", font, 20.0));
+
+        let done = false;
+        MenuScene {
+            title_text,
+            input_text,
+            done,
+        }
+    }
+}
+
+impl scene::Scene<World, input::Event> for MenuScene {
+    fn update(&mut self, gameworld: &mut World, ctx: &mut ggez::Context) -> scenes::Switch {
+        if self.done {
+            self.done = false;
+            scene::SceneSwitch::Push(Box::new(scenes::level::LevelScene::new(ctx, gameworld)))
+        } else {
+            scene::SceneSwitch::None
+        }
+    }
+
+    fn draw(&mut self, _gameworld: &mut World, ctx: &mut ggez::Context) -> ggez::GameResult<()> {
+        graphics::draw(
+            ctx,
+            &self.title_text,
+            graphics::DrawParam::default().dest(Point2::new(200.0,200.0)),
+        )?;
+        graphics::draw(
+            ctx,
+            &self.input_text,
+            graphics::DrawParam::default().dest(Point2::new(200.0,300.0)),
+        )?;
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "MenuScene"
+    }
+
+    fn input(&mut self, _gameworld: &mut World, ev: input::Event, _started: bool) {
+        debug!("Input: {:?}", ev);
+        self.done = true;
+    }
+}

--- a/src/scenes/mod.rs
+++ b/src/scenes/mod.rs
@@ -4,6 +4,7 @@ use crate::input;
 use crate::world::World;
 
 pub mod level;
+pub mod menu;
 
 // Shortcuts for our scene type.
 pub type Switch = scene::SceneSwitch<World, input::Event>;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -7,15 +7,16 @@ pub struct MovementSystem;
 impl<'a> specs::System<'a> for MovementSystem {
     type SystemData = (
         specs::WriteStorage<'a, Position>,
-        specs::ReadStorage<'a, Motion>,
+        specs::WriteStorage<'a, Motion>,
     );
 
-    fn run(&mut self, (mut pos, motion): Self::SystemData) {
+    fn run(&mut self, (mut pos, mut motion): Self::SystemData) {
         // The `.join()` combines multiple components,
         // so we only access those entities which have
         // both of them.
-        for (pos, motion) in (&mut pos, &motion).join() {
+        for (pos, motion) in (&mut pos, &mut motion).join() {
             pos.0 += motion.velocity;
+            motion.velocity += motion.acceleration;
         }
     }
 }


### PR DESCRIPTION
I was using this template for a game jam and decided to open a PR to fix a few snags I ran into. 

First off I fixed up the current input system so that get_button_pressed can trigger. This fixes #8.

I realized that acceleration wasn't actually being accounted for in the motion system so I updated that as well.

Finally, now that the menu button works, I decided to actually create a small menu state so that pressing Z doesn't just crash the game by popping an empty stack.

I'm quite new to rust and ggez so any advice / changes are welcome. I don't really understand warmy either, but I figure it could probably be used for the text in the menu I made.